### PR TITLE
feat: (M1.6) Protect Admin/Mentor/Student areas based on role implement admi…

### DIFF
--- a/src/app/(admin)/admin-dashboard/page.tsx
+++ b/src/app/(admin)/admin-dashboard/page.tsx
@@ -1,0 +1,11 @@
+// 🧭 Bu sayfa sadece admin kullanıcılar tarafından görülebilir.
+// Amaç: Admin paneli için başlangıç noktası
+
+export default function AdminDashboard() {
+  return (
+    <div className="p-6">
+      <h1 className="text-2xl font-bold">Admin Dashboard</h1>
+      <p className="mt-2 text-gray-600">Yalnızca admin rolüne sahip kullanıcılar buraya erişebilir.</p>
+    </div>
+  )
+}

--- a/src/app/(admin)/layout.tsx
+++ b/src/app/(admin)/layout.tsx
@@ -1,0 +1,15 @@
+import { getServerSession } from "next-auth"
+import { authOptions } from "@/lib/auth/nextauth"
+import { redirect } from "next/navigation"
+
+export default async function AdminLayout({ children }: { children: React.ReactNode }) {
+  const session = await getServerSession(authOptions)
+
+  // Giriş yapılmamışsa → signin sayfasına yönlendir
+  if (!session?.user) redirect("/signin")
+
+  // Rol admin değilse → anasayfaya yönlendir
+  if (session.user.role !== "ADMIN") redirect("/")
+
+  return <>{children}</>
+}

--- a/src/app/(mentor)/layout.tsx
+++ b/src/app/(mentor)/layout.tsx
@@ -1,0 +1,19 @@
+import { getServerSession } from "next-auth"
+import { authOptions } from "@/lib/auth/nextauth"
+import { redirect } from "next/navigation"
+
+// 🔐 Bu layout, sadece mentor rolüne sahip kullanıcıların erişebileceği sayfaları korur.
+
+export default async function MentorLayout({ children }: { children: React.ReactNode }) {
+  const session = await getServerSession(authOptions)
+
+  if (!session?.user) {
+    redirect("/signin")
+  }
+
+  if (session.user.role !== "MENTOR") {
+    redirect("/")
+  }
+
+  return <>{children}</>
+}

--- a/src/app/(mentor)/mentor-dashboard/page.tsx
+++ b/src/app/(mentor)/mentor-dashboard/page.tsx
@@ -1,0 +1,10 @@
+// 🧭 Bu sayfa sadece mentor kullanıcılar tarafından görülebilir.
+
+export default function MentorDashboard() {
+  return (
+    <div className="p-6">
+      <h1 className="text-2xl font-bold">Mentor Dashboard</h1>
+      <p className="mt-2 text-gray-600">Yalnızca mentor rolüne sahip kullanıcılar buraya erişebilir.</p>
+    </div>
+  )
+}

--- a/src/app/(student)/layout.tsx
+++ b/src/app/(student)/layout.tsx
@@ -1,0 +1,19 @@
+import { getServerSession } from "next-auth"
+import { authOptions } from "@/lib/auth/nextauth"
+import { redirect } from "next/navigation"
+
+// 🔐 Bu layout, sadece student rolüne sahip kullanıcıların erişebileceği sayfaları korur.
+
+export default async function StudentLayout({ children }: { children: React.ReactNode }) {
+  const session = await getServerSession(authOptions)
+
+  if (!session?.user) {
+    redirect("/signin")
+  }
+
+  if (session.user.role !== "STUDENT") {
+    redirect("/")
+  }
+
+  return <>{children}</>
+}

--- a/src/app/(student)/student-dashboard/page.tsx
+++ b/src/app/(student)/student-dashboard/page.tsx
@@ -1,0 +1,10 @@
+// 🧭 Bu sayfa sadece student kullanıcılar tarafından görülebilir.
+
+export default function StudentDashboard() {
+  return (
+    <div className="p-6">
+      <h1 className="text-2xl font-bold">Student Dashboard</h1>
+      <p className="mt-2 text-gray-600">Yalnızca student rolüne sahip kullanıcılar buraya erişebilir.</p>
+    </div>
+  )
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import { DebugNavbar } from "@/components/DebugNavbar"
+import { SessionProvider } from "@/components/SessionProvider"
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -27,7 +29,14 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
+        {/* 🔐 NextAuth oturum sağlayıcısı */}
+        <SessionProvider>
+
+       {/* 🧭 Oturum bilgisi (email + role) burada gösterilir */}
+        <DebugNavbar />
+
         {children}
+        </SessionProvider>
       </body>
     </html>
   );

--- a/src/components/DebugNavbar.tsx
+++ b/src/components/DebugNavbar.tsx
@@ -1,0 +1,18 @@
+"use client"
+import { useSession } from "next-auth/react"
+
+export function DebugNavbar() {
+  const { data: session } = useSession()
+
+  return (
+    <div className="p-4 text-sm text-gray-600 border-b bg-gray-50">
+      {session?.user?.email ? (
+        <p>
+          <strong>Oturum:</strong> {session.user.email} | <strong>Rol:</strong> {session.user.role}
+        </p>
+      ) : (
+        <p>Giriş yapılmamış</p>
+      )}
+    </div>
+  )
+}

--- a/src/components/SessionProvider.tsx
+++ b/src/components/SessionProvider.tsx
@@ -1,0 +1,13 @@
+"use client"
+import { SessionProvider as NextAuthProvider } from "next-auth/react"
+import type { Session } from "next-auth"
+
+export function SessionProvider({
+  children,
+  session,
+}: {
+  children: React.ReactNode
+  session?: Session
+}) {
+  return <NextAuthProvider session={session}>{children}</NextAuthProvider>
+}


### PR DESCRIPTION
…n, mentor, and student dashboard layouts with role-based access control; add DebugNavbar and SessionProvider components for session management Goal: Protect Admin/Mentor/Student areas based on role.

Tasks

src/app/(admin), (mentor), (student) segments and layouts.

Server-side guard: read role from session; redirect if not authorized.

Simple placeholder pages: Admin Dashboard, Mentor Dashboard, Student Dashboard.

Display session and role info in the navbar (simple debug display).

Acceptance Criteria

Each role can only access its own segment.

Unauthenticated users are redirected to the public page